### PR TITLE
チャンネル登録、解除機能

### DIFF
--- a/app/adapter/infrastructure/user.go
+++ b/app/adapter/infrastructure/user.go
@@ -12,6 +12,8 @@ import (
 	"github.com/yuorei/video-server/app/domain"
 	"github.com/yuorei/video-server/app/driver/db/mongodb/collection"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 func (i *Infrastructure) GetUserFromDB(ctx context.Context, id string) (*domain.User, error) {
@@ -66,4 +68,85 @@ func (i *Infrastructure) GetProfileImageURL(ctx context.Context, id string) (str
 	}
 
 	return profileImageURL.URL, nil
+}
+
+func (i *Infrastructure) AddSubscribeChannelForDB(ctx context.Context, subscribeChannel *domain.SubscribeChannel) (*domain.SubscribeChannel, error) {
+	mongoCollection := i.db.Database.Collection("user")
+	if mongoCollection == nil {
+		return nil, fmt.Errorf("collection is nil")
+	}
+
+	// チャンネル登録していないかを確認している
+	var result bson.M
+	err := mongoCollection.FindOne(ctx, bson.M{"subscribechannelid": subscribeChannel.ChannelID}).Decode(&result)
+	if err != nil {
+		if err != mongo.ErrNoDocuments {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("already subscribed")
+	}
+
+	//チャンネルが存在するかを確認する
+	err = mongoCollection.FindOne(ctx, bson.M{"_id": subscribeChannel.ChannelID}).Decode(&result)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, fmt.Errorf("Channel does not exist")
+		}
+		return nil, fmt.Errorf("error while checking ChannelID existence: %v", err)
+	}
+
+	// チャンネルを登録する
+	filter := bson.M{"_id": subscribeChannel.UserID}
+	update := bson.M{
+		"$addToSet": bson.M{"subscribechannelid": subscribeChannel.ChannelID},
+	}
+	options := options.Update().SetUpsert(true)
+
+	_, err = mongoCollection.UpdateOne(ctx, filter, update, options)
+	if err != nil {
+		return nil, fmt.Errorf("error while updating user: %v", err)
+	}
+	subscribeChannel.IsSuccess = true
+
+	return subscribeChannel, nil
+}
+
+func (i *Infrastructure) UnSubscribeChannelForDB(ctx context.Context, subscribeChannel *domain.SubscribeChannel) (*domain.SubscribeChannel, error) {
+	mongoCollection := i.db.Database.Collection("user")
+	if mongoCollection == nil {
+		return nil, fmt.Errorf("collection is nil")
+	}
+
+	// チャンネル登録しているかを確認している
+	var result bson.M
+	err := mongoCollection.FindOne(ctx, bson.M{"subscribechannelid": subscribeChannel.ChannelID}).Decode(&result)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, fmt.Errorf("ChannelID does not exist")
+		}
+		return nil, err
+	}
+	//チャンネルが存在するかを確認する
+	err = mongoCollection.FindOne(ctx, bson.M{"_id": subscribeChannel.ChannelID}).Decode(&result)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, fmt.Errorf("Channel does not exist")
+		}
+		return nil, fmt.Errorf("error while checking ChannelID existence: %v", err)
+	}
+
+	// チャンネルを解除する
+	filter := bson.M{"_id": subscribeChannel.UserID}
+	update := bson.M{
+		"$pull": bson.M{"subscribechannelid": subscribeChannel.ChannelID},
+	}
+
+	_, err = mongoCollection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return nil, fmt.Errorf("error while updating user: %v", err)
+	}
+	subscribeChannel.IsSuccess = true
+
+	return subscribeChannel, nil
 }

--- a/app/adapter/presentation/resolver/user.resolvers.go
+++ b/app/adapter/presentation/resolver/user.resolvers.go
@@ -35,7 +35,7 @@ func (r *mutationResolver) SubscribeChannel(ctx context.Context, input *model.Su
 		return nil, err
 	}
 
-	subscribeChannel := domain.NewSubscribeChannel(id,input.ChannelID)
+	subscribeChannel := domain.NewSubscribeChannel(id, input.ChannelID)
 	subscribeChannelResult, err := r.usecase.SubscribeChannel(ctx, subscribeChannel)
 	if err != nil {
 		return nil, err
@@ -53,7 +53,7 @@ func (r *mutationResolver) UnSubscribeChannel(ctx context.Context, input *model.
 		return nil, err
 	}
 
-	subscribeChannel := domain.NewSubscribeChannel(id,input.ChannelID)
+	subscribeChannel := domain.NewSubscribeChannel(id, input.ChannelID)
 	subscribeChannelResult, err := r.usecase.UnSubscribeChannel(ctx, subscribeChannel)
 	if err != nil {
 		return nil, err

--- a/app/adapter/presentation/resolver/user.resolvers.go
+++ b/app/adapter/presentation/resolver/user.resolvers.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/yuorei/video-server/app/domain"
 	model "github.com/yuorei/video-server/app/domain/models"
 	"github.com/yuorei/video-server/graph/generated"
+	"github.com/yuorei/video-server/middleware"
 )
 
 // RegisterUser is the resolver for the registerUser field.
@@ -23,6 +25,42 @@ func (r *mutationResolver) RegisterUser(ctx context.Context, input model.UserInp
 		ID:              user.ID,
 		Name:            user.Name,
 		ProfileImageURL: user.ProfileImageURL,
+	}, nil
+}
+
+// SubscribeChannel is the resolver for the subscribeChannel field.
+func (r *mutationResolver) SubscribeChannel(ctx context.Context, input *model.SubscribeChannelInput) (*model.SubscriptionPayload, error) {
+	id, err := middleware.GetUserIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	subscribeChannel := domain.NewSubscribeChannel(id,input.ChannelID)
+	subscribeChannelResult, err := r.usecase.SubscribeChannel(ctx, subscribeChannel)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.SubscriptionPayload{
+		IsSuccess: subscribeChannelResult.IsSuccess,
+	}, nil
+}
+
+// UnSubscribeChannel is the resolver for the unSubscribeChannel field.
+func (r *mutationResolver) UnSubscribeChannel(ctx context.Context, input *model.SubscribeChannelInput) (*model.SubscriptionPayload, error) {
+	id, err := middleware.GetUserIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	subscribeChannel := domain.NewSubscribeChannel(id,input.ChannelID)
+	subscribeChannelResult, err := r.usecase.UnSubscribeChannel(ctx, subscribeChannel)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.SubscriptionPayload{
+		IsSuccess: subscribeChannelResult.IsSuccess,
 	}, nil
 }
 

--- a/app/application/port/user_port.go
+++ b/app/application/port/user_port.go
@@ -10,10 +10,14 @@ import (
 type UserInputPort interface {
 	GetUser(context.Context, string) (*domain.User, error)
 	RegisterUser(context.Context) (*domain.User, error)
+	SubscribeChannel(context.Context, *domain.SubscribeChannel) (*domain.SubscribeChannel, error)
+	UnSubscribeChannel(context.Context, *domain.SubscribeChannel) (*domain.SubscribeChannel, error)
 }
 
 type UserRepository interface {
 	GetProfileImageURL(context.Context, string) (string, error)
 	GetUserFromDB(context.Context, string) (*domain.User, error)
 	InsertUser(context.Context, *domain.User) (*domain.User, error)
+	AddSubscribeChannelForDB(context.Context, *domain.SubscribeChannel) (*domain.SubscribeChannel, error)
+	UnSubscribeChannelForDB(context.Context, *domain.SubscribeChannel) (*domain.SubscribeChannel, error)
 }

--- a/app/application/user.go
+++ b/app/application/user.go
@@ -41,3 +41,11 @@ func (a *Application) RegisterUser(ctx context.Context) (*domain.User, error) {
 	user := domain.NewUser(id, name, profileImageURL)
 	return a.User.userRepository.InsertUser(ctx, user)
 }
+
+func (a *Application) SubscribeChannel(ctx context.Context, subscribeChannel *domain.SubscribeChannel) (*domain.SubscribeChannel, error) {
+	return a.User.userRepository.AddSubscribeChannelForDB(ctx, subscribeChannel)
+}
+
+func (a *Application) UnSubscribeChannel(ctx context.Context, subscribeChannel *domain.SubscribeChannel) (*domain.SubscribeChannel, error) {
+	return a.User.userRepository.UnSubscribeChannelForDB(ctx, subscribeChannel)
+}

--- a/app/domain/models/models_gen.go
+++ b/app/domain/models/models_gen.go
@@ -25,6 +25,10 @@ type PostCommentPayload struct {
 	User      *User  `json:"user,omitempty"`
 }
 
+type SubscriptionPayload struct {
+	IsSuccess bool `json:"isSuccess"`
+}
+
 type UploadVideoInput struct {
 	Video          graphql.Upload  `json:"video"`
 	ThumbnailImage *graphql.Upload `json:"thumbnailImage,omitempty"`
@@ -74,4 +78,8 @@ type VideoPayload struct {
 	CreatedAt         string  `json:"createdAt"`
 	UpdatedAt         string  `json:"updatedAt"`
 	Uploader          *User   `json:"uploader"`
+}
+
+type SubscribeChannelInput struct {
+	ChannelID string `json:"channelID"`
 }

--- a/app/domain/user.go
+++ b/app/domain/user.go
@@ -1,10 +1,22 @@
 package domain
 
-type User struct {
-	ID              string
-	Name            string
-	ProfileImageURL string
-}
+type (
+	User struct {
+		ID              string
+		Name            string
+		ProfileImageURL string
+	}
+
+	SubscribeChannel struct {
+		UserID    string
+		ChannelID string
+		IsSuccess bool
+	}
+
+	ProfileImageURL struct {
+		URL string `json:"url"`
+	}
+)
 
 func NewUser(id, name, profileImageURL string) *User {
 	return &User{
@@ -14,6 +26,10 @@ func NewUser(id, name, profileImageURL string) *User {
 	}
 }
 
-type ProfileImageURL struct {
-	URL string `json:"url"`
+func NewSubscribeChannel(userID, channelID string) *SubscribeChannel {
+	return &SubscribeChannel{
+		UserID:    userID,
+		ChannelID: channelID,
+		IsSuccess: false,
+	}
 }

--- a/app/driver/db/mongodb/collection/user.go
+++ b/app/driver/db/mongodb/collection/user.go
@@ -2,9 +2,10 @@ package collection
 
 type (
 	User struct {
-		ID              string `bson:"_id"`
-		Name            string
-		ProfileImageURL string
+		ID                 string `bson:"_id"`
+		Name               string
+		ProfileImageURL    string
+		SubscribeChannelID []string
 	}
 )
 

--- a/graph/schema/user.graphqls
+++ b/graph/schema/user.graphqls
@@ -10,17 +10,25 @@ type UserPayload {
   profileImageURL: String!
 }
 
+input UserInput {
+  name: String!
+}
+
+input subscribeChannelInput {
+  channelID: ID!
+}
+
+type SubscriptionPayload {
+  isSuccess: Boolean!
+}
+
 extend type Query {
   users: [User!]!
   user(id: ID!): User!
 }
 
-input UserInput {
-  name: String!
-}
-
-
-
 type Mutation {
   registerUser(input: UserInput!): UserPayload!
+  subscribeChannel(input: subscribeChannelInput): SubscriptionPayload!
+  unSubscribeChannel(input: subscribeChannelInput): SubscriptionPayload!
 }


### PR DESCRIPTION
## タスク
チャンネル登録、解除機能できるようにした
<!-- issueなどのリンクを貼る -->

## 背景
チャンネル登録機能があるとよいので
<!-- このプルリクを作成する背景を書く -->

## やったこと
チャンネル登録と解除をできるようにしました。
mongodbのuserコレクションに`subscribechannelid`を追加しました。これは配列で登録しているチャンネル(userID)を管理しています。


## やらないこと

<!-- このプルリクでやらないことは何か（あるなら書く。やらない場合は、いつやるのかを明記する。）-->

## 仕様変更（ユーザ目線）
チャンネル登録ができる
<!-- 何ができるようになるのか（あれば。無いなら「無し」でOK）-->

## できなくなること（ユーザ目線）

<!-- 何ができなくなるのか（あれば。無いなら「無し」でOK）-->
## チェックシート

- [x] 動作確認をした
- [x] 第3者や将来の自分が読んでも理解できるように実装、コメントを書いた
- [x] 複雑な仕様はコードのコメントを残した
- [x] TODOコメントには、いつになったら対応できるかを記載した
- [ ] テストを書いた
- [x] テストが通ることを確認した

## 動作確認
```

mutation subscribeChannel{
  subscribeChannel(input: { channelID: "ID" }) {
    isSuccess
  }
}

mutation unSubscribeChannel{
  unSubscribeChannel(input: {channelID: "ID"}) {
    isSuccess
  }
}

```

認証のためのトークンが必要です
<!-- どのような動作確認を行ったのか-->

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）-->